### PR TITLE
remove false copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 MIT License
 
-Copyright (c) 2021 Hiro Systems PBC
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
This PR removes false copyright statement.

I'm original author of these syntax highlighting rules (source repo: https://github.com/LNow/vscode-clarity). I've never been employed by Hiro Systems PBC and I also never transferred my rights to Hiro Systems PBC. I only agreed this code to be used in `clarity-lsp` project which happen in this commit: https://github.com/hirosystems/clarity-lsp/commit/a1e2808e13a8c4de4993389eb409d7c359248bcd and then to publish it as a separate repository to get Clarity added to list of languages recognizable in all github.com repositories.