### PR TITLE
feat: add clarity 4 functions and keywords

### DIFF
--- a/Syntaxes/clarity.JSON-tmLanguage
+++ b/Syntaxes/clarity.JSON-tmLanguage
@@ -31,7 +31,7 @@
     },
     "keyword": {
       "name": "constant.language.clarity",
-      "match": "(?<!\\S)(?!-)\\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?)\\b(?!\\s*-)"
+      "match": "(?<!\\S)(?!-)\\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?|current-contract|block-time)\\b(?!\\s*-)"
     },
     "define-function": {
       "begin": "(?x) (\\() \\s* (define-(?:public|private|read-only)) \\s+",
@@ -465,7 +465,7 @@
       ]
     },
     "built-in-func": {
-      "begin": "(?x) (\\() \\s* (\\-|\\+|<\\=|>\\=|<|>|\\*|/|and|append|as-contract|as-max-len\\?|asserts!|at-block|begin|bit-and|bit-not|bit-or|bit-shift-left|bit-shift-right|bit-xor|buff-to-int-be|buff-to-int-le|buff-to-uint-be|buff-to-uint-le|concat|contract-call\\?|contract-of|default-to|element-at|element-at\\?|filter|fold|from-consensus-buff\\?|ft-burn\\?|ft-get-balance|ft-get-supply|ft-mint\\?|ft-transfer\\?|get-block-info\\?|get-burn-block-info\\?|get-stacks-block-info\\?|get-tenure-info\\?|get-burn-block-info\\?|hash160|if|impl-trait|index-of|index-of\\?|int-to-ascii|int-to-utf8|is-eq|is-err|is-none|is-ok|is-some|is-standard|keccak256|len|log2|map|match|merge|mod|nft-burn\\?|nft-get-owner\\?|nft-mint\\?|nft-transfer\\?|not|or|pow|principal-construct\\?|principal-destruct\\?|principal-of\\?|print|replace-at\\?|secp256k1-recover\\?|secp256k1-verify|sha256|sha512|sha512/256|slice\\?|sqrti|string-to-int\\?|string-to-uint\\?|stx-account|stx-burn\\?|stx-get-balance|stx-transfer-memo\\?|stx-transfer\\?|to-consensus-buff\\?|to-int|to-uint|try!|unwrap!|unwrap-err!|unwrap-err-panic|unwrap-panic|xor) \\s+",
+      "begin": "(?x) (\\() \\s* (\\-|\\+|<\\=|>\\=|<|>|\\*|/|and|append|as-contract|as-contract\\?|as-max-len\\?|asserts!|at-block|begin|bit-and|bit-not|bit-or|bit-shift-left|bit-shift-right|bit-xor|buff-to-int-be|buff-to-int-le|buff-to-uint-be|buff-to-uint-le|concat|contract-call\\?|contract-of|default-to|element-at|element-at\\?|filter|fold|from-consensus-buff\\?|ft-burn\\?|ft-get-balance|ft-get-supply|ft-mint\\?|ft-transfer\\?|get-block-info\\?|get-burn-block-info\\?|get-stacks-block-info\\?|get-tenure-info\\?|hash160|if|impl-trait|index-of|index-of\\?|int-to-ascii|int-to-utf8|is-eq|is-err|is-none|is-ok|is-some|is-standard|keccak256|len|log2|map|match|merge|mod|nft-burn\\?|nft-get-owner\\?|nft-mint\\?|nft-transfer\\?|not|or|pow|principal-construct\\?|principal-destruct\\?|principal-of\\?|print|replace-at\\?|secp256k1-recover\\?|secp256k1-verify|sha256|sha512|sha512/256|slice\\?|sqrti|string-to-int\\?|string-to-uint\\?|to-ascii\\?|stx-account|stx-burn\\?|stx-get-balance|stx-transfer-memo\\?|stx-transfer\\?|to-consensus-buff\\?|to-int|to-uint|try!|unwrap!|unwrap-err!|unwrap-err-panic|unwrap-panic|xor|contract-hash\\?|restrict-assets\\?|with-stx|with-ft|with-nft|with-stacking|with-all-assets-unsafe|secp256r1-recover\\?|secp256r1-verify) \\s+",
       "end": "(\\))",
       "beginCaptures": {
         "1": { "name": "punctuation.built-in-function.start.clarity" },

--- a/Syntaxes/clarity.YAML-tmLanguage
+++ b/Syntaxes/clarity.YAML-tmLanguage
@@ -26,7 +26,7 @@ repository:
                   - include: "#get-set-func"
       keyword:
             name: constant.language.clarity
-            match: (?<!\S)(?!-)\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?)\b(?!\s*-)
+            match: (?<!\S)(?!-)\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?|current-contract|block-time)\b(?!\s*-)
       define-function:
             begin: (?x) (\() \s* (define-(?:public|private|read-only)) \s+
             end: (\))
@@ -411,7 +411,7 @@ repository:
                           - include: "#data-type"
       built-in-func:
             begin: (?x) (\() \s*
-                  (\-|\+|<\=|>\=|<|>|\*|/|and|append|as-contract|as-max-len\?|asserts!|at-block|begin|bit-and|bit-not|bit-or|bit-shift-left|bit-shift-right|bit-xor|buff-to-int-be|buff-to-int-le|buff-to-uint-be|buff-to-uint-le|concat|contract-call\?|contract-of|default-to|element-at|element-at\?|filter|fold|from-consensus-buff\?|ft-burn\?|ft-get-balance|ft-get-supply|ft-mint\?|ft-transfer\?|get-block-info\?|get-burn-block-info\?|get-stacks-block-info\?|get-tenure-info\?|hash160|if|impl-trait|index-of|index-of\?|int-to-ascii|int-to-utf8|is-eq|is-err|is-none|is-ok|is-some|is-standard|keccak256|len|log2|map|match|merge|mod|nft-burn\?|nft-get-owner\?|nft-mint\?|nft-transfer\?|not|or|pow|principal-construct\?|principal-destruct\?|principal-of\?|print|replace-at\?|secp256k1-recover\?|secp256k1-verify|sha256|sha512|sha512/256|slice\?|sqrti|string-to-int\?|string-to-uint\?|stx-account|stx-burn\?|stx-get-balance|stx-transfer-memo\?|stx-transfer\?|to-consensus-buff\?|to-int|to-uint|try!|unwrap!|unwrap-err!|unwrap-err-panic|unwrap-panic|xor)
+                  (\-|\+|<\=|>\=|<|>|\*|/|and|append|as-contract|as-contract\?|as-max-len\?|asserts!|at-block|begin|bit-and|bit-not|bit-or|bit-shift-left|bit-shift-right|bit-xor|buff-to-int-be|buff-to-int-le|buff-to-uint-be|buff-to-uint-le|concat|contract-call\?|contract-of|default-to|element-at|element-at\?|filter|fold|from-consensus-buff\?|ft-burn\?|ft-get-balance|ft-get-supply|ft-mint\?|ft-transfer\?|get-block-info\?|get-burn-block-info\?|get-stacks-block-info\?|get-tenure-info\?|hash160|if|impl-trait|index-of|index-of\?|int-to-ascii|int-to-utf8|is-eq|is-err|is-none|is-ok|is-some|is-standard|keccak256|len|log2|map|match|merge|mod|nft-burn\?|nft-get-owner\?|nft-mint\?|nft-transfer\?|not|or|pow|principal-construct\?|principal-destruct\?|principal-of\?|print|replace-at\?|secp256k1-recover\?|secp256k1-verify|sha256|sha512|sha512/256|slice\?|sqrti|string-to-int\?|string-to-uint\?|to-ascii\?|stx-account|stx-burn\?|stx-get-balance|stx-transfer-memo\?|stx-transfer\?|to-consensus-buff\?|to-int|to-uint|try!|unwrap!|unwrap-err!|unwrap-err-panic|unwrap-panic|xor|contract-hash\?|restrict-assets\?|with-stx|with-ft|with-nft|with-stacking|with-all-assets-unsafe|secp256r1-recover\?|secp256r1-verify)
                   \s+
             end: (\))
             beginCaptures:

--- a/Syntaxes/clarity.tmLanguage
+++ b/Syntaxes/clarity.tmLanguage
@@ -93,7 +93,7 @@
         <key>name</key>
         <string>constant.language.clarity</string>
         <key>match</key>
-        <string>(?&lt;!\S)(?!-)\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?)\b(?!\s*-)</string>
+        <string>(?&lt;!\S)(?!-)\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?|current-contract|block-time)\b(?!\s*-)</string>
       </dict>
       <key>define-function</key>
       <dict>
@@ -1139,7 +1139,7 @@
       <key>built-in-func</key>
       <dict>
         <key>begin</key>
-        <string>(?x) (\() \s* (\-|\+|&lt;\=|&gt;\=|&lt;|&gt;|\*|/|and|append|as-contract|as-max-len\?|asserts!|at-block|begin|bit-and|bit-not|bit-or|bit-shift-left|bit-shift-right|bit-xor|buff-to-int-be|buff-to-int-le|buff-to-uint-be|buff-to-uint-le|concat|contract-call\?|contract-of|default-to|element-at|element-at\?|filter|fold|from-consensus-buff\?|ft-burn\?|ft-get-balance|ft-get-supply|ft-mint\?|ft-transfer\?|get-block-info\?|get-burn-block-info\?|get-stacks-block-info\?|get-tenure-info\?|hash160|if|impl-trait|index-of|index-of\?|int-to-ascii|int-to-utf8|is-eq|is-err|is-none|is-ok|is-some|is-standard|keccak256|len|log2|map|match|merge|mod|nft-burn\?|nft-get-owner\?|nft-mint\?|nft-transfer\?|not|or|pow|principal-construct\?|principal-destruct\?|principal-of\?|print|replace-at\?|secp256k1-recover\?|secp256k1-verify|sha256|sha512|sha512/256|slice\?|sqrti|string-to-int\?|string-to-uint\?|stx-account|stx-burn\?|stx-get-balance|stx-transfer-memo\?|stx-transfer\?|to-consensus-buff\?|to-int|to-uint|try!|unwrap!|unwrap-err!|unwrap-err-panic|unwrap-panic|xor) \s+</string>
+        <string>(?x) (\() \s* (\-|\+|&lt;\=|&gt;\=|&lt;|&gt;|\*|/|and|append|as-contract|as-contract\?|as-max-len\?|asserts!|at-block|begin|bit-and|bit-not|bit-or|bit-shift-left|bit-shift-right|bit-xor|buff-to-int-be|buff-to-int-le|buff-to-uint-be|buff-to-uint-le|concat|contract-call\?|contract-of|default-to|element-at|element-at\?|filter|fold|from-consensus-buff\?|ft-burn\?|ft-get-balance|ft-get-supply|ft-mint\?|ft-transfer\?|get-block-info\?|get-burn-block-info\?|get-stacks-block-info\?|get-tenure-info\?|hash160|if|impl-trait|index-of|index-of\?|int-to-ascii|int-to-utf8|is-eq|is-err|is-none|is-ok|is-some|is-standard|keccak256|len|log2|map|match|merge|mod|nft-burn\?|nft-get-owner\?|nft-mint\?|nft-transfer\?|not|or|pow|principal-construct\?|principal-destruct\?|principal-of\?|print|replace-at\?|secp256k1-recover\?|secp256k1-verify|sha256|sha512|sha512/256|slice\?|sqrti|string-to-int\?|string-to-uint\?|to-ascii\?|stx-account|stx-burn\?|stx-get-balance|stx-transfer-memo\?|stx-transfer\?|to-consensus-buff\?|to-int|to-uint|try!|unwrap!|unwrap-err!|unwrap-err-panic|unwrap-panic|xor|contract-hash\?|restrict-assets\?|with-stx|with-ft|with-nft|with-stacking|with-all-assets-unsafe|secp256r1-recover\?|secp256r1-verify) \s+</string>
         <key>end</key>
         <string>(\))</string>
         <key>beginCaptures</key>


### PR DESCRIPTION
Support for Clarity 4.

The YAML and JSON are generated from `Syntaxes/clarity.tmLanguage`.
Based on the Clarity 4 SIP: https://github.com/stacksgov/sips/blob/7c78d3af982826b4a4a7e3fd0266af97cdc61802/sips/sip-clarity4/sip-clarity4.md

Adding
Keywords:
- `current-contract`
- `block-time`

Functions
- `as-contract?`
- `to-ascii?`
- `contract-hash?`
- `restrict-assets?`
- `with-stx`
- `with-ft`
- `with-nft`
- `with-stacking`
- `with-all-assets-unsafe`
- `secp256r1-recover?`
- `secp256r1-verify`

A slightly better diff than the one provided by github:

<img width="2276" height="459" alt="Screenshot 2025-10-02 at 17 53 23" src="https://github.com/user-attachments/assets/ad1c4fc7-ea64-4fbf-9426-e571d820c870" />
